### PR TITLE
feat(headers): add custom headers support and centralize header management

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The Pica SDK can be configured with the following options:
 | authkit | Boolean | No | false | If true, the SDK will use Authkit to connect to prompt the user to connect to a platform that they do not currently have access to |
 | knowledgeAgent | Boolean | No | false | If true, the SDK will never execute actions, but will use Pica's knowledge to generate code. If true, use pica.intelligenceTool instead of pica.oneTool |
 | knowledgeAgentConfig | Object | No | `{ includeEnvironmentVariables: true }` | Configuration for the Knowledge Agent. If `includeEnvironmentVariables` is true, the SDK will return a reminder to include environment variables in the output |
+| headers | Record<string, string> | No | - | Additional headers to send with all requests (e.g., cookies, custom authentication headers) |
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@picahq/ai",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@picahq/ai",
-            "version": "2.6.0",
+            "version": "2.7.0",
             "license": "GPL-3.0",
             "dependencies": {
                 "axios": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@picahq/ai",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "description": "Pica AI SDK for Vercel AI SDK integration",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/pica.ts
+++ b/src/pica.ts
@@ -26,6 +26,7 @@ interface PicaOptions {
    * @property authkit - Whether to enable AuthKit integration
    * @property knowledgeAgent - Whether to enable Knowledge Agent mode
    * @property knowledgeAgentConfig - Configuration options for Knowledge Agent
+   * @property headers - Additional headers to send with requests
    */
   connectors?: string[];
   actions?: string[];
@@ -36,6 +37,7 @@ interface PicaOptions {
   authkit?: boolean;
   knowledgeAgent?: boolean;
   knowledgeAgentConfig?: KnowledgeAgentConfig;
+  headers?: Record<string, string>;
 }
 
 interface KnowledgeAgentConfig {
@@ -157,7 +159,10 @@ ${this.system.trim()}
 
   private async initializeConnections(platform?: string) {
     try {
-      const headers = this.generateHeaders();
+      const headers = {
+        ...this.generateHeaders(),
+        ...this.options?.headers
+      };
 
       let baseUrl = this.getConnectionUrl;
       let hasQueryParam = false;
@@ -197,7 +202,10 @@ ${this.system.trim()}
 
   private async initializeConnectionDefinitions() {
     try {
-      const headers = this.generateHeaders();
+      const headers = {
+        ...this.generateHeaders(),
+        ...this.options?.headers
+      };
 
       let url = this.getConnectionDefinitionsUrl;
       let hasQueryParam = false;
@@ -246,7 +254,12 @@ ${this.system.trim()}
           limit: number
         }>(
           `${this.availableActionsUrl}?supported=true&connectionPlatform=${platform}&skip=${skip}&limit=${limit}`,
-          { headers: this.generateHeaders() }
+          {
+            headers: {
+              ...this.generateHeaders(),
+              ...this.options?.headers
+            }
+          }
         ).then(response => response.data);
 
       const results = await paginateResults<AvailableActions>(fetchPage);
@@ -312,7 +325,12 @@ ${this.system.trim()}
         limit: number
       }>(
         `${this.availableActionsUrl}?_id=${normalizedActionId}`,
-        { headers: this.generateHeaders() }
+        {
+          headers: {
+            ...this.generateHeaders(),
+            ...this.options?.headers
+          }
+        }
       );
 
       if (!response.data.rows || response.data.rows.length === 0) {
@@ -365,7 +383,8 @@ ${this.system.trim()}
         'x-pica-action-id': actionId,
         ...(isFormData ? { 'Content-Type': 'multipart/form-data' } : {}),
         ...(isFormUrlEncoded ? { 'Content-Type': 'application/x-www-form-urlencoded' } : {}),
-        ...headers
+        ...headers,
+        ...this.options?.headers
       };
 
       const url = `${this.baseUrl}/v1/passthrough${path.startsWith('/') ? path : '/' + path}`;
@@ -393,7 +412,7 @@ ${this.system.trim()}
 
           requestConfig.data = formData;
 
-          Object.assign(requestConfig.headers, formData.getHeaders());
+          Object.assign(requestConfig.headers, formData.getHeaders(), this.options?.headers);
         } else if (isFormUrlEncoded) {
           const params = new URLSearchParams();
 

--- a/src/pica.ts
+++ b/src/pica.ts
@@ -159,10 +159,7 @@ ${this.system.trim()}
 
   private async initializeConnections(platform?: string) {
     try {
-      const headers = {
-        ...this.generateHeaders(),
-        ...this.options?.headers
-      };
+      const headers = this.generateHeaders();
 
       let baseUrl = this.getConnectionUrl;
       let hasQueryParam = false;
@@ -202,10 +199,7 @@ ${this.system.trim()}
 
   private async initializeConnectionDefinitions() {
     try {
-      const headers = {
-        ...this.generateHeaders(),
-        ...this.options?.headers
-      };
+      const headers = this.generateHeaders();
 
       let url = this.getConnectionDefinitionsUrl;
       let hasQueryParam = false;
@@ -241,6 +235,7 @@ ${this.system.trim()}
     return {
       "Content-Type": "application/json",
       "x-pica-secret": this.secret,
+      ...this.options?.headers
     };
   }
 
@@ -254,12 +249,7 @@ ${this.system.trim()}
           limit: number
         }>(
           `${this.availableActionsUrl}?supported=true&connectionPlatform=${platform}&skip=${skip}&limit=${limit}`,
-          {
-            headers: {
-              ...this.generateHeaders(),
-              ...this.options?.headers
-            }
-          }
+          { headers: this.generateHeaders() }
         ).then(response => response.data);
 
       const results = await paginateResults<AvailableActions>(fetchPage);
@@ -325,12 +315,7 @@ ${this.system.trim()}
         limit: number
       }>(
         `${this.availableActionsUrl}?_id=${normalizedActionId}`,
-        {
-          headers: {
-            ...this.generateHeaders(),
-            ...this.options?.headers
-          }
-        }
+        { headers: this.generateHeaders() }
       );
 
       if (!response.data.rows || response.data.rows.length === 0) {
@@ -383,8 +368,7 @@ ${this.system.trim()}
         'x-pica-action-id': actionId,
         ...(isFormData ? { 'Content-Type': 'multipart/form-data' } : {}),
         ...(isFormUrlEncoded ? { 'Content-Type': 'application/x-www-form-urlencoded' } : {}),
-        ...headers,
-        ...this.options?.headers
+        ...headers
       };
 
       const url = `${this.baseUrl}/v1/passthrough${path.startsWith('/') ? path : '/' + path}`;
@@ -412,7 +396,7 @@ ${this.system.trim()}
 
           requestConfig.data = formData;
 
-          Object.assign(requestConfig.headers, formData.getHeaders(), this.options?.headers);
+          Object.assign(requestConfig.headers, formData.getHeaders());
         } else if (isFormUrlEncoded) {
           const params = new URLSearchParams();
 


### PR DESCRIPTION
- Add headers option to PicaOptions interface for custom header injection
- Refactor generateHeaders() to include custom headers automatically
- Remove repetitive header spreading across all HTTP requests
- Consolidate header logic in single method for better maintainability